### PR TITLE
Add basic React Native client

### DIFF
--- a/mobile/.gitignore
+++ b/mobile/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.expo

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+import { View, Text, Button, ActivityIndicator, Alert } from 'react-native';
+import * as DocumentPicker from 'expo-document-picker';
+import * as FileSystem from 'expo-file-system';
+import { Audio } from 'expo-av';
+
+const API_BASE = 'http://localhost:8888';
+
+export default function App() {
+  const [loading, setLoading] = useState(false);
+  const [playing, setPlaying] = useState(false);
+
+  const pickFileAndUpload = async () => {
+    const doc = await DocumentPicker.getDocumentAsync({
+      type: ['text/plain', 'application/pdf', 'application/epub+zip'],
+    });
+    if (doc.canceled) return;
+
+    setLoading(true);
+    try {
+      const result = await FileSystem.uploadAsync(
+        `${API_BASE}/generate/music`,
+        doc.assets[0].uri,
+        {
+          fieldName: 'file',
+          httpMethod: 'POST',
+          uploadType: FileSystem.FileSystemUploadType.MULTIPART,
+          parameters: { book_id: 'demo', page: '1' },
+        }
+      );
+
+      const data = JSON.parse(result.body);
+      if (!data.download_url) throw new Error('No download URL');
+
+      const url = `${API_BASE}${data.download_url}`;
+      const { sound } = await Audio.Sound.createAsync({ uri: url });
+      setPlaying(true);
+      await sound.playAsync();
+    } catch (e) {
+      console.error(e);
+      Alert.alert('Error', 'Failed to generate music');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text style={{ fontSize: 24, marginBottom: 20 }}>Readning Mobile</Text>
+      <Button title="Select File" onPress={pickFileAndUpload} />
+      {loading && <ActivityIndicator style={{ marginTop: 20 }} />}
+      {playing && <Text style={{ marginTop: 20 }}>Playing generated music...</Text>}
+    </View>
+  );
+}

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,0 +1,16 @@
+# Readning Mobile
+
+A simple React Native (Expo) client for the Readning API. It lets you select a text or PDF file, uploads it to the FastAPI server, and plays the generated background music.
+
+## Requirements
+- Node.js
+- Expo CLI (`npm install -g expo-cli`)
+
+## Development
+```bash
+cd mobile
+npm install
+npm start # then use Expo Go or a simulator
+```
+
+Update `API_BASE` in `App.tsx` with the address of your running FastAPI server.

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -1,0 +1,10 @@
+{
+  "expo": {
+    "name": "ReadningMobile",
+    "slug": "readning-mobile",
+    "version": "1.0.0",
+    "sdkVersion": "50.0.0",
+    "platforms": ["ios", "android"],
+    "assetBundlePatterns": ["**/*"]
+  }
+}

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "readning-mobile",
+  "version": "1.0.0",
+  "main": "node_modules/expo/AppEntry.js",
+  "private": true,
+  "scripts": {
+    "start": "expo start",
+    "android": "expo run:android",
+    "ios": "expo run:ios"
+  },
+  "dependencies": {
+    "expo": "^50.0.17",
+    "expo-av": "^13.7.2",
+    "expo-document-picker": "^15.4.1",
+    "expo-file-system": "^15.4.1",
+    "react": "18.2.0",
+    "react-native": "0.73.6"
+  },
+  "devDependencies": {
+    "@types/react": "~18.2.14",
+    "@types/react-native": "~0.73.7",
+    "typescript": "^5.2.2"
+  }
+}

--- a/mobile/tsconfig.json
+++ b/mobile/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "module": "esnext",
+    "jsx": "react",
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
## Summary
- add a new `mobile` folder with an Expo React Native app
- include instructions for running the app

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688cde0036788333a01cd4acb686fbc7